### PR TITLE
optimize Trigrams

### DIFF
--- a/caisson_test.go
+++ b/caisson_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+//go:embed main.go
+var main_go string
+
+func BenchmarkTrigrams(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Trigrams(main_go)
+	}
+}
+
+func TestTrigrams(t *testing.T) {
+	tcs := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"a", nil},
+		{"ab", nil},
+		{"abc", []string{"abc"}},
+		{"abcd", []string{"abc", "bcd"}},
+	}
+	for _, tc := range tcs {
+		got := Trigrams(tc.in)
+		if !cmp.Equal(got, tc.want, cmpopts.EquateEmpty()) {
+			t.Errorf("Trigrams(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module indexer
 
 go 1.20
+
+require github.com/google/go-cmp v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
Nerd-snipe successful :) This isn't really production-ready or anything, it's just how far I got during your talk. I'd be happy to try to do more, but I think it would be beneficial to have the full context and I couldn't find the actual server code.

Some low-hanging fruit. With more context, there could probably be more savings (like replacing the []string return with an iterator-type).

On my machine, this speeds up the simple benchmark from ~200 μs/op to ~80 μs/op.