### PR TITLE
Nerdsniped - GC2023

### DIFF
--- a/caisson.go
+++ b/caisson.go
@@ -8,6 +8,7 @@ import (
 	"hash/fnv"
 	"sort"
 	"strings"
+	"unicode/utf8"
 )
 
 var (
@@ -112,9 +113,25 @@ func Trigrams(text string) []string {
 // trigrams takes in text and inserts its trigrams to the result slice starting at location.
 // Attempts to be as efficient as possible
 func trigrams(text string, result []string, location int) int {
-	runes := []rune(text)
-	for i := 0; i < len(runes)-2; i++ {
-		result[i+location] = string(runes[i : i+3])
+	l := len(text)
+	if l < 3 {
+		return 0
+	}
+
+	// set up vars to track locations in the text as we walk
+	st, mid, end, tmp := 0, 0, 0, 0
+
+	// mid = index of second rune
+	// end = index of third rune
+	_, mid = utf8.DecodeRuneInString(text)
+	_, tmp = utf8.DecodeRuneInString(text[mid:])
+	end = mid + tmp
+	for end < l {
+		result[location] = text[st : end+1]
+		_, tmp = utf8.DecodeRuneInString(text[end:])
+		// update start, mid, end = old+mid, old_end, new_end=old_end+tmp
+		st, mid, end = mid, end, end+tmp
+		location++
 	}
 	return len(text) - 2
 }

--- a/caisson.go
+++ b/caisson.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 )
 
-var currentBlockDocumentCount = 0
-var bloomFilter []uint64
-var currentDocumentCount = 0
-var currentBlockStartDocumentCount = 0
+var (
+	currentBlockDocumentCount      = 0
+	bloomFilter                    []uint64
+	currentDocumentCount           = 0
+	currentBlockStartDocumentCount = 0
+)
 
 // Search the results we need to look at very quickly using only bit operations
 // mostly limited by memory access
@@ -62,21 +64,25 @@ func Search(queryBits []uint64) []uint32 {
 
 // Tokenize returns a slice of tokens for the given text.
 func Tokenize(text string) []string {
+	// First loop prepares the input and computes the slice size required for the final result
 	res := strings.Fields(strings.ToLower(text))
-	var cres []string
-	for _, v := range res {
-		if len(v) >= 3 {
-			cres = append(cres, v)
+	cres := make([]string, 0, len(res))
+	finalLength := 0
+	for _, field := range res {
+		// ignore words that cannot be trigrammed
+		if len(field) > 2 {
+			cres = append(cres, field)
+			finalLength += len(field) - 2
 		}
 	}
 
-	// now we have clean tokens trigram them
-	var trigrams []string
-	for _, r := range cres {
-		trigrams = append(trigrams, Trigrams(r)...)
+	// allocate and computes the final trigram slice
+	result := make([]string, finalLength)
+	current := 0
+	for _, field := range cres {
+		current += trigrams(field, result, current)
 	}
-
-	return trigrams
+	return result
 }
 
 // Itemise given some content will turn it into tokens
@@ -94,27 +100,23 @@ func Itemise(tokens []string) []bool {
 }
 
 // Trigrams takes in text and returns its trigrams
-// Attempts to be as efficient as possible
 func Trigrams(text string) []string {
-	var runes = []rune(text)
-
-	// if we have less than or 2 runes we cannot do anything so bail out
-	if len(runes) <= 2 {
+	if len(text) < 3 {
 		return []string{}
 	}
+	result := make([]string, len(text)-2)
+	trigrams(text, result, 0)
+	return result
+}
 
-	// we always need this many ngrams, so preallocate to avoid expanding the slice
-	// which is the most expensive thing in here according to profiles
-	ngrams := make([]string, len(runes)-2)
-
-	for i := 0; i < len(runes); i++ {
-		if i+3 < len(runes)+1 {
-			ngram := runes[i : i+3]
-			ngrams[i] = string(ngram)
-		}
+// trigrams takes in text and inserts its trigrams to the result slice starting at location.
+// Attempts to be as efficient as possible
+func trigrams(text string, result []string, location int) int {
+	runes := []rune(text)
+	for i := 0; i < len(runes)-2; i++ {
+		result[i+location] = string(runes[i : i+3])
 	}
-
-	return ngrams
+	return len(text) - 2
 }
 
 // Queryise given some content will turn it into tokens
@@ -142,7 +144,7 @@ func RemoveUInt64Duplicates(s []uint64) []uint64 {
 		return s
 	}
 	sort.Slice(s, func(x, y int) bool { return s[x] > s[y] })
-	var e = 1
+	e := 1
 	for i := 1; i < len(s); i++ {
 		if s[i] == s[i-1] {
 			continue
@@ -237,7 +239,7 @@ func PrintIndex() {
 // Ngrams given input splits it according the requested size
 // such that you can get trigrams or whatever else is required
 func Ngrams(text string, size int) []string {
-	var runes = []rune(text)
+	runes := []rune(text)
 
 	var ngrams []string
 

--- a/caisson_benchmark_test.go
+++ b/caisson_benchmark_test.go
@@ -1,0 +1,22 @@
+package main
+
+import "testing"
+
+var res []string
+
+/*
+goos: darwin
+goarch: arm64
+pkg: indexer
+BenchmarkTokenize-10    	  139582	      7814 ns/op	    8760 B/op	     243 allocs/op
+PASS
+ok  	indexer	1.287s
+*/
+func BenchmarkTokenize(b *testing.B) {
+	const text = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`
+	var result []string
+	for n := 0; n < b.N; n++ {
+		result = Tokenize(text)
+	}
+	res = result
+}

--- a/caisson_benchmark_test.go
+++ b/caisson_benchmark_test.go
@@ -8,9 +8,9 @@ var res []string
 goos: darwin
 goarch: arm64
 pkg: indexer
-BenchmarkTokenize-10    	  139582	      7814 ns/op	    8760 B/op	     243 allocs/op
+BenchmarkTokenize-10    	  458174	      2656 ns/op	    6848 B/op	       4 allocs/op
 PASS
-ok  	indexer	1.287s
+ok  	indexer	2.477s
 */
 func BenchmarkTokenize(b *testing.B) {
 	const text = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`

--- a/caisson_test.go
+++ b/caisson_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTrigrams(t *testing.T) {
+	for _, testCase := range []struct {
+		text     string
+		expected []string
+	}{
+		{"", []string{}},
+		{"ab", []string{}},
+		{"abc", []string{"abc"}},
+		{"ABC", []string{"ABC"}},
+		{"abcd", []string{"abc", "bcd"}},
+		{"a b c", []string{"a b", " b ", "b c"}},
+	} {
+		testCase := testCase
+		t.Run(testCase.text, func(t *testing.T) {
+			result := Trigrams(testCase.text)
+			if !reflect.DeepEqual(result, testCase.expected) {
+				t.Errorf("Trigrams(%v)=%v, got %v", testCase.text, result, testCase.expected)
+			}
+		})
+	}
+}
+
+func TestTokenize(t *testing.T) {
+	for _, testCase := range []struct {
+		text     string
+		expected []string
+	}{
+		{"", []string{}},
+		{"ab", []string{}},
+		{"abc", []string{"abc"}},
+		{"ABC", []string{"abc"}},
+		{"AbCd", []string{"abc", "bcd"}},
+
+		// Multi-word tests
+		{"abc def", []string{"abc", "def"}},
+		{"abcd efg", []string{"abc", "bcd", "efg"}},
+		{"abc abc", []string{"abc", "abc"}},
+		{"abc de", []string{"abc"}},
+	} {
+		testCase := testCase
+		t.Run(testCase.text, func(t *testing.T) {
+			result := Tokenize(testCase.text)
+			if !reflect.DeepEqual(result, testCase.expected) {
+				t.Errorf("Tokenize(%v)=%v, got %v", testCase.text, result, testCase.expected)
+			}
+		})
+	}
+}

--- a/caisson_test.go
+++ b/caisson_test.go
@@ -21,7 +21,7 @@ func TestTrigrams(t *testing.T) {
 		t.Run(testCase.text, func(t *testing.T) {
 			result := Trigrams(testCase.text)
 			if !reflect.DeepEqual(result, testCase.expected) {
-				t.Errorf("Trigrams(%v)=%v, got %v", testCase.text, result, testCase.expected)
+				t.Errorf("Trigrams(%v)=%v, expected %v", testCase.text, result, testCase.expected)
 			}
 		})
 	}
@@ -49,7 +49,7 @@ func TestTokenize(t *testing.T) {
 		t.Run(testCase.text, func(t *testing.T) {
 			result := Tokenize(testCase.text)
 			if !reflect.DeepEqual(result, testCase.expected) {
-				t.Errorf("Tokenize(%v)=%v, got %v", testCase.text, result, testCase.expected)
+				t.Errorf("Tokenize(%v)=%v, expected %v", testCase.text, result, testCase.expected)
 			}
 		})
 	}

--- a/caisson_test.go
+++ b/caisson_test.go
@@ -43,6 +43,7 @@ func TestTokenize(t *testing.T) {
 		{"abcd efg", []string{"abc", "bcd", "efg"}},
 		{"abc abc", []string{"abc", "abc"}},
 		{"abc de", []string{"abc"}},
+		{"abc de fghi", []string{"abc", "fgh", "ghi"}},
 	} {
 		testCase := testCase
 		t.Run(testCase.text, func(t *testing.T) {


### PR DESCRIPTION
Attempting an improvement on the (use of the) Trigram function.

We do this by moving the slice allocation outside the trigram function. `Trigrams` is only used by `Tokenize`, and that function can actually compute the result slice size while cleaning up the input. The `trigram` function now takes the result slice and a location to start populating the output.

Since this inherently changes the function signature, we unexport it, and export the `Trigram` method as a wrapper for this unexported function that implements the old function signature. Since the exported method must behave as per the old code, it still needs to do its own memory alloc, and as a result does not see much improvement. Most of the improvement here is seen in the `Tokenize` method.

Benchmarks on `Tokenize` (on my machine) show ~1.5x improvement

```sh
# NEW
goos: darwin
goarch: arm64
pkg: indexer
BenchmarkTokenize-10    	  139582	      7814 ns/op	    8760 B/op	     243 allocs/op
PASS
ok  	indexer	1.287s

# OLD
goos: darwin
goarch: arm64
pkg: indexer
BenchmarkTokenize-10    	  101376	     11273 ns/op	   21608 B/op	     312 allocs/op
PASS
ok  	indexer	1.369s
```

UPDATE: credit to @Merovius for this idea
Second optimization: remove the alloc for a []rune slice in the trigram function by walking the string with 3 variables to keep track of a start, middle, and end index, using the utf8 package DecodeRune function to find an appropriate increment each iteration without the need to allocate the rune slice.

This brings the final time down to ~2.6us per call to `Tokenize`, a **~4.2x improvment**

```sh
goos: darwin
goarch: arm64
pkg: indexer
BenchmarkTokenize-10    	  458174	      2656 ns/op	    6848 B/op	       4 allocs/op
PASS
ok  	indexer	2.477s
```