### PR TITLE
[GC2023] Simple fix for allocation overhead

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,18 +1,37 @@
 package main
 
-import "testing"
+import (
+	_ "embed"
+	"testing"
+)
+
+//go:embed caisson.go
+var trigramexample string
 
 func BenchmarkTrigrams(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = Trigrams("this is a test")
+		_ = Trigrams(trigramexample)
 	}
 }
 
-func BenchmarkTokenize(b *testing.B) {
-	const text = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`
-	var result []Trigram
-	for n := 0; n < b.N; n++ {
-		result = Tokenize(text)
+func BenchmarkTrigramBytes(b *testing.B) {
+	trigrams := Trigrams(trigramexample)
+
+	for i := 0; i < b.N; i++ {
+		trigrams[i%len(trigrams)].Bytes()
 	}
-	_ = result
+}
+
+func BenchmarkTrigramBytesFast(b *testing.B) {
+	trigrams := Trigrams(trigramexample)
+
+	for i := 0; i < b.N; i++ {
+		trigrams[i%len(trigrams)].BytesFast()
+	}
+}
+
+func BenchmarkItemise(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_ = Itemise(Tokenize(trigramexample))
+	}
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+func BenchmarkTrigrams(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = Trigrams("this is a test")
+	}
+}
+
+func BenchmarkTokenize(b *testing.B) {
+	const text = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`
+	var result []Trigram
+	for n := 0; n < b.N; n++ {
+		result = Tokenize(text)
+	}
+	_ = result
+}


### PR DESCRIPTION
A type, `Trigram` is defined as 3 runes. This saves time spent in the expensive allocation. Benchmarks show a **2.6x** improvement with this simple fix alone.

**Before:**
```
goos: darwin
goarch: arm64
pkg: indexer
BenchmarkTrigrams-10             3804986               310.9 ns/op
BenchmarkTokenize-10              104250             11147 ns/op
PASS
ok      indexer 2.885s
```

**After:**
```
goos: darwin
goarch: arm64
pkg: indexer
BenchmarkTrigrams-10            22071332                48.99 ns/op
BenchmarkTokenize-10              273313              4267 ns/op
PASS
ok      indexer 2.438s
```

(Thanks to #2 for the `BenchmarkTokenize` test)