### PR TITLE
Use Trigrams from #3 + Benchmark

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// setupBench is a non-interactive version of main that can be used for
+// benchmarking. Heavily lifted from main(), I just wrote this because it
+// seemed easier than running the tests manually one-by-one.
+// wrapped in sync.OnceFunc because it changes global state and we only need to
+// seed the bloom filter once.
+var setupBench = sync.OnceFunc(func() {
+	// walk the directory getting files and indexing
+	_ = filepath.Walk(".", func(root string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil // we only care about files
+		}
+
+		res, err := os.ReadFile(root)
+		if err != nil {
+			return nil // swallow error
+		}
+
+		// don't index binary files by looking for nul byte, similar to how grep does it
+		if bytes.IndexByte(res, 0) != -1 {
+			return nil
+		}
+
+		// only index up to about 5kb
+		if len(res) > 5000 {
+			res = res[:5000]
+		}
+
+		// add the document to the index
+		_ = Add(Itemise(Tokenize(string(res))))
+		// store the association from what's in the index to the filename, we know its 0 to whatever so this works
+		idToFile = append(idToFile, root)
+		return nil
+	})
+})
+
+func BenchmarkMain(b *testing.B) {
+	trigramMethod = "jamesrom"
+	setupBench()
+	for i := 0; i < b.N; i++ {
+		Search(Queryise("test"))
+	}
+}


### PR DESCRIPTION
I've created a new PR that shows how using the `Trigram` type introduced in #3 can save time and allocations over `string`. The advantages of using a triple of rune instead of converting back to string becomes apparent: the runtime does not need to do the UTF-8 conversion which runs [something like this](https://github.com/golang/go/blob/master/src/unicode/utf8/utf8.go#L342) for every rune.

I also added a benchmark that simulates running main so you can compare implementations. Here's the results (on my Windows PC tonight):

**default:**
```
goos: windows
goarch: amd64
pkg: indexer
cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
BenchmarkMain-8   	 1042885	      1021 ns/op	     552 B/op	      21 allocs/op
PASS
ok  	indexer	1.686s
```

**merovius:**
```
goos: windows
goarch: amd64
pkg: indexer
cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
BenchmarkMain-8   	 1146393	      1055 ns/op	     552 B/op	      21 allocs/op
PASS
ok  	indexer	2.347s
```

**dancantos:**
```
goos: windows
goarch: amd64
pkg: indexer
cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
BenchmarkMain-8   	 1131397	      1047 ns/op	     520 B/op	      21 allocs/op
PASS
ok  	indexer	2.233s
```

**ffmiruz:**
```
goos: windows
goarch: amd64
pkg: indexer
cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
BenchmarkMain-8   	 1142209	      1038 ns/op	     552 B/op	      21 allocs/op
PASS
ok  	indexer	2.264s
```

**jamesrom:**
```
goos: windows
goarch: amd64
pkg: indexer
cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
BenchmarkMain-8   	 1214605	       939.6 ns/op	     496 B/op	      20 allocs/op
PASS
ok  	indexer	2.264s
```

_Note, all of these tests are using my `.BytesFast()`, so the savings are not from that alone. The point is that using Trigram instead of string saves on unnecessary UTF-8 conversion._

Maybe these different implementations should be controlled via a [build tag](https://pkg.go.dev/go/build#hdr-Build_Constraints), so that we can compare using Trigram vs string independently?